### PR TITLE
Remove offsetLeft/offsetTop entirely.

### DIFF
--- a/src/example/plot/static-hints.js
+++ b/src/example/plot/static-hints.js
@@ -47,7 +47,7 @@ export default class Example extends React.Component {
             {x: 3, y: 15}
           ]}/>
         <Hint value={{x: 1, y: 10}}/>
-        <Hint value={{x: 0.4, y: 14}} orientation="topleft">
+        <Hint value={{x: 0.4, y: 14}} orientation="bottomright">
           <div className="custom-hint">
             This is a custom hint<br />
             for a non-existent value

--- a/src/lib/plot/hint.js
+++ b/src/lib/plot/hint.js
@@ -147,20 +147,20 @@ export default class Hint extends PureRenderComponent {
     let yCSS;
 
     if (orientation === ORIENTATION_AUTO) {
-      xCSS = (x > innerWidth / 2) ? this._getCSSRight(x) : this._getCSSLeft(x);
-      yCSS = (y > innerHeight / 2) ? this._getCSSBottom(y) : this._getCSSTop(y);
+      xCSS = (x > innerWidth / 2) ? this._getCSSLeft(x) : this._getCSSRight(x);
+      yCSS = (y > innerHeight / 2) ? this._getCSSTop(y) : this._getCSSBottom(y);
     } else {
       if (orientation === ORIENTATION_BOTTOMLEFT ||
         orientation === ORIENTATION_BOTTOMRIGHT) {
-        yCSS = this._getCSSBottom(y);
-      } else {
         yCSS = this._getCSSTop(y);
+      } else {
+        yCSS = this._getCSSBottom(y);
       }
       if (orientation === ORIENTATION_TOPLEFT ||
         orientation === ORIENTATION_BOTTOMLEFT) {
-        xCSS = this._getCSSLeft(x);
-      } else {
         xCSS = this._getCSSRight(x);
+      } else {
+        xCSS = this._getCSSLeft(x);
       }
     }
     return {

--- a/src/lib/plot/hint.js
+++ b/src/lib/plot/hint.js
@@ -54,8 +54,6 @@ export default class Hint extends PureRenderComponent {
       scales: React.PropTypes.object,
       value: React.PropTypes.object,
       format: React.PropTypes.func,
-      offsetTop: React.PropTypes.number,
-      offsetLeft: React.PropTypes.number,
       orientation: React.PropTypes.oneOf([
         ORIENTATION_AUTO,
         ORIENTATION_BOTTOMLEFT,
@@ -68,8 +66,6 @@ export default class Hint extends PureRenderComponent {
 
   static get defaultProps() {
     return {
-      offsetTop: 0,
-      offsetLeft: 0,
       format: defaultFormat,
       orientation: ORIENTATION_AUTO
     };
@@ -84,10 +80,9 @@ export default class Hint extends PureRenderComponent {
   _getCSSRight(x) {
     const {
       innerWidth,
-      marginRight,
-      offsetLeft} = this.props;
+      marginRight} = this.props;
     return {
-      right: `${marginRight + offsetLeft + innerWidth - x}px`
+      right: `${marginRight + innerWidth - x}px`
     };
   }
 
@@ -98,11 +93,9 @@ export default class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSLeft(x) {
-    const {
-      marginLeft,
-      offsetLeft} = this.props;
+    const {marginLeft} = this.props;
     return {
-      left: `${marginLeft + offsetLeft + x}px`
+      left: `${marginLeft + x}px`
     };
   }
 
@@ -115,10 +108,9 @@ export default class Hint extends PureRenderComponent {
   _getCSSBottom(y) {
     const {
       innerHeight,
-      marginBottom,
-      offsetTop} = this.props;
+      marginBottom} = this.props;
     return {
-      bottom: `${marginBottom + offsetTop + innerHeight - y}px`
+      bottom: `${marginBottom + innerHeight - y}px`
     };
   }
 
@@ -129,11 +121,9 @@ export default class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSTop(y) {
-    const {
-      marginTop,
-      offsetTop} = this.props;
+    const {marginTop} = this.props;
     return {
-      top: `${marginTop + offsetTop + y}px`
+      top: `${marginTop + y}px`
     };
   }
 


### PR DESCRIPTION
Removing offsets for hints entirely: we don't need them on the chart. The changes can be made with CSS.

This change will solve #14.

@uber-common/data-visualization, please review.