### PR TITLE
Fix custom values for scales.

### DIFF
--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -159,8 +159,8 @@ function _getDomainByAttr(allData, attr, type) {
  */
 function _createScaleObjectForValue(attr, value) {
   return {
-    type: 'linear',
-    range: [value, value],
+    type: 'category',
+    range: [value],
     domain: [],
     distance: 0,
     attr,


### PR DESCRIPTION
Custom values (e.g. color={someColor}) for scales did not work well. The problem was hidden in the linear scale that could not return a function for string values. Now the issue is fixed by using `category` scale instead.

@uber-common/data-visualization , please review.