### PR TITLE
Add zero to bar chart; align bar items to 0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -306,7 +306,7 @@
     ],
     "max-params": [
       2,
-      5
+      7
     ],
     "max-statements": [
       2,

--- a/src/example/plot/complex-chart.js
+++ b/src/example/plot/complex-chart.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   makeWidthFlexible,
   LineSeries,
-  BarSeries,
+  VerticalBarSeries,
   Crosshair} from '../../';
 
 const FlexibleXYPlot = makeWidthFlexible(XYPlot);
@@ -134,7 +134,7 @@ export default class Example extends React.Component {
           <HorizontalGridLines />
           <YAxis />
           <XAxis />
-          <BarSeries
+          <VerticalBarSeries
             onNearestX={this._onNearestXs[0]}
             data={this.state.data[0]}/>
           <LineSeries

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,10 @@ export {default as Treemap} from './lib/treemap/treemap';
 export {default as XYPlot} from './lib/plot/xy-plot';
 
 export {default as LineSeries} from './lib/plot/series/line-series';
-export {default as BarSeries} from './lib/plot/series/bar-series';
+export {default as VerticalBarSeries}
+  from './lib/plot/series/vertical-bar-series';
+export {default as HorizontalBarSeries}
+  from './lib/plot/series/horizontal-bar-series';
 export {default as MarkSeries} from './lib/plot/series/mark-series';
 export {default as HeatmapSeries} from './lib/plot/series/heatmap-series';
 export {default as AreaSeries} from './lib/plot/series/area-series';

--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -60,6 +60,14 @@ export default class AbstractSeries extends PureRenderComponent {
   }
 
   /**
+   * Get a default config for the parent.
+   * @returns {Object} Empty config.
+   */
+  static getParentConfig() {
+    return {};
+  }
+
+  /**
    * Get attribute functor.
    * @param {string} attr Attribute name
    * @returns {*} Functor.
@@ -89,6 +97,11 @@ export default class AbstractSeries extends PureRenderComponent {
   _getScaleDistance(attr) {
     const scaleObject = getScaleObjectFromProps(this.props, attr);
     return scaleObject ? scaleObject.distance : 0;
+  }
+
+  _getScaleBaseValue(attr) {
+    const scaleObject = getScaleObjectFromProps(this.props, attr);
+    return scaleObject ? scaleObject.baseValue : 0;
   }
 
   /**

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -32,8 +32,10 @@ export default class AreaSeries extends AbstractSeries {
     return 'AreaSeries';
   }
 
-  static isDomainAdjustmentNeeded() {
-    return false;
+  static getParentConfig() {
+    return {
+      isDomainAdjustmentNeeded: false
+    };
   }
 
   constructor(props) {

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -32,12 +32,6 @@ export default class AreaSeries extends AbstractSeries {
     return 'AreaSeries';
   }
 
-  static getParentConfig() {
-    return {
-      isDomainAdjustmentNeeded: false
-    };
-  }
-
   constructor(props) {
     super(props);
     this._mouseOut = this._mouseOut.bind(this);

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -24,34 +24,16 @@ import d3 from 'd3';
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
 
-const VERTICAL_ORIENTATION = 'vertical';
-const HORIZONTAL_ORIENTATION = 'horizontal';
-
 export default class BarSeries extends AbstractSeries {
 
   static get propTypes() {
     return {
       ... AbstractSeries.propTypes,
-      orientation: React.PropTypes.oneOf([
-        VERTICAL_ORIENTATION, HORIZONTAL_ORIENTATION
-      ])
+      linePosAttr: React.PropTypes.string,
+      valuePosAttr: React.PropTypes.string,
+      lineSizeAttr: React.PropTypes.string,
+      valueSizeAttr: React.PropTypes.string
     };
-  }
-
-  static get defaultProps() {
-    return {
-      orientation: VERTICAL_ORIENTATION
-    };
-  }
-
-  static getParentConfig(attr, props) {
-    let isDomainAdjustmentNeeded;
-    if (props.orientation === VERTICAL_ORIENTATION) {
-      isDomainAdjustmentNeeded = attr === 'x';
-    } else {
-      isDomainAdjustmentNeeded = attr === 'y';
-    }
-    return {isDomainAdjustmentNeeded};
   }
 
   constructor(props) {
@@ -98,37 +80,6 @@ export default class BarSeries extends AbstractSeries {
     }
   }
 
-  /**
-   * Get necessary variables to get orientation from.
-   * @returns {Object} Config.
-   * @private
-   */
-  _getOrientationConfig() {
-    const {
-      orientation,
-      innerWidth,
-      innerHeight} = this.props;
-    let result;
-    if (orientation === VERTICAL_ORIENTATION) {
-      result = {
-        linePosAttr: 'x',
-        valuePosAttr: 'y',
-        lineSizeAttr: 'width',
-        valueSizeAttr: 'height',
-        lineSpace: innerWidth
-      };
-    } else {
-      result = {
-        linePosAttr: 'y',
-        valuePosAttr: 'x',
-        lineSizeAttr: 'height',
-        valueSizeAttr: 'width',
-        lineSpace: innerHeight
-      };
-    }
-    return result;
-  }
-
   _updateSeries() {
     const container = getDOMNode(this.refs.container);
     const {
@@ -140,14 +91,14 @@ export default class BarSeries extends AbstractSeries {
       lineSizeAttr,
       valuePosAttr,
       linePosAttr,
-      valueSizeAttr} = this._getOrientationConfig();
+      valueSizeAttr} = this.props;
 
     if (!data || !data.length) {
       return;
     }
 
     const distance = this._getScaleDistance(linePosAttr);
-    const [baseValue] = this._getScaleDomain(valuePosAttr);
+    const baseValue = this._getScaleBaseValue(valuePosAttr);
     const lineFunctor = this._getAttributeFunctor(linePosAttr);
     const valueFunctor = this._getAttributeFunctor(valuePosAttr);
 

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -29,10 +29,6 @@ const HORIZONTAL_ORIENTATION = 'horizontal';
 
 export default class BarSeries extends AbstractSeries {
 
-  static get displayName() {
-    return 'BarSeries';
-  }
-
   static get propTypes() {
     return {
       ... AbstractSeries.propTypes,
@@ -48,11 +44,14 @@ export default class BarSeries extends AbstractSeries {
     };
   }
 
-  static isDomainAdjustmentNeeded(attr, props) {
+  static getParentConfig(attr, props) {
+    let isDomainAdjustmentNeeded;
     if (props.orientation === VERTICAL_ORIENTATION) {
-      return attr === 'x';
+      isDomainAdjustmentNeeded = attr === 'x';
+    } else {
+      isDomainAdjustmentNeeded = attr === 'y';
     }
-    return attr === 'y';
+    return {isDomainAdjustmentNeeded};
   }
 
   constructor(props) {

--- a/src/lib/plot/series/heatmap-series.js
+++ b/src/lib/plot/series/heatmap-series.js
@@ -30,8 +30,9 @@ export default class HeatmapSeries extends AbstractSeries {
     return 'HeatmapSeries';
   }
 
-  static isDomainAdjustmentNeeded(attr) {
-    return attr === 'x' || attr === 'y';
+  static getParentConfig(attr) {
+    const isDomainAdjustmentNeeded = attr === 'x' || attr === 'y';
+    return {isDomainAdjustmentNeeded};
   }
 
   constructor(props) {

--- a/src/lib/plot/series/horizontal-bar-series.js
+++ b/src/lib/plot/series/horizontal-bar-series.js
@@ -20,37 +20,29 @@
 
 import React from 'react';
 
-import {
-  XYPlot,
-  XAxis,
-  YAxis,
-  VerticalGridLines,
-  HorizontalGridLines,
-  VerticalBarSeries} from '../../';
+import AbstractSeries from './abstract-series';
+import BarSeries from './bar-series';
 
-export default class Example extends React.Component {
+export default class HorizontalBarSeries extends AbstractSeries {
+
+  static getParentConfig(attr) {
+    const isDomainAdjustmentNeeded = attr === 'y';
+    const zeroBaseValue = attr === 'x';
+    return {
+      isDomainAdjustmentNeeded,
+      zeroBaseValue
+    };
+  }
+
   render() {
     return (
-      <XYPlot
-        width={300}
-        height={300}>
-        <VerticalGridLines />
-        <HorizontalGridLines />
-        <XAxis />
-        <YAxis />
-        <VerticalBarSeries
-          data={[
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <VerticalBarSeries
-          data={[
-            {x: 1, y: 12},
-            {x: 2, y: 2},
-            {x: 3, y: 11}
-          ]}/>
-      </XYPlot>
+      <BarSeries
+        {...this.props}
+        linePosAttr="y"
+        valuePosAttr="x"
+        lineSizeAttr="height"
+        valueSizeAttr="width"
+      />
     );
   }
 }

--- a/src/lib/plot/series/line-mark-series.js
+++ b/src/lib/plot/series/line-mark-series.js
@@ -33,14 +33,6 @@ export default class LineMarkSeries extends AbstractSeries {
     return LineSeries.defaultProps;
   }
 
-  static getParentConfig(attr) {
-    return false;
-  }
-
-  getParentConfig() {
-    return false;
-  }
-
   render() {
     return (
       <g className="rv-xy-plot__series rv-xy-plot__series--linemark">

--- a/src/lib/plot/series/line-mark-series.js
+++ b/src/lib/plot/series/line-mark-series.js
@@ -33,11 +33,11 @@ export default class LineMarkSeries extends AbstractSeries {
     return LineSeries.defaultProps;
   }
 
-  static isDomainAdjustmentNeeded(attr) {
+  static getParentConfig(attr) {
     return false;
   }
 
-  isDomainAdjustmentNeeded() {
+  getParentConfig() {
     return false;
   }
 

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -44,8 +44,8 @@ export default class LineSeries extends AbstractSeries {
     };
   }
 
-  static isDomainAdjustmentNeeded() {
-    return false;
+  static getParentConfig() {
+    return {isDomainAdjustmentNeeded: false};
   }
 
   constructor(props) {

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -44,10 +44,6 @@ export default class LineSeries extends AbstractSeries {
     };
   }
 
-  static getParentConfig() {
-    return {isDomainAdjustmentNeeded: false};
-  }
-
   constructor(props) {
     super(props);
     this._mouseOver = this._mouseOver.bind(this);

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -32,10 +32,6 @@ export default class MarkSeries extends AbstractSeries {
     return 'MarkSeries';
   }
 
-  static getParentConfig() {
-    return {isDomainAdjustmentNeeded: false};
-  }
-
   constructor(props) {
     super(props);
     this._mouseOver = this._mouseOver.bind(this);

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -32,8 +32,8 @@ export default class MarkSeries extends AbstractSeries {
     return 'MarkSeries';
   }
 
-  static isDomainAdjustmentNeeded() {
-    return false;
+  static getParentConfig() {
+    return {isDomainAdjustmentNeeded: false};
   }
 
   constructor(props) {

--- a/src/lib/plot/series/vertical-bar-series.js
+++ b/src/lib/plot/series/vertical-bar-series.js
@@ -20,37 +20,29 @@
 
 import React from 'react';
 
-import {
-  XYPlot,
-  XAxis,
-  YAxis,
-  VerticalGridLines,
-  HorizontalGridLines,
-  VerticalBarSeries} from '../../';
+import AbstractSeries from './abstract-series';
+import BarSeries from './bar-series';
 
-export default class Example extends React.Component {
+export default class VerticalBarSeries extends AbstractSeries {
+
+  static getParentConfig(attr) {
+    const isDomainAdjustmentNeeded = attr === 'x';
+    const zeroBaseValue = attr === 'y';
+    return {
+      isDomainAdjustmentNeeded,
+      zeroBaseValue
+    };
+  }
+
   render() {
     return (
-      <XYPlot
-        width={300}
-        height={300}>
-        <VerticalGridLines />
-        <HorizontalGridLines />
-        <XAxis />
-        <YAxis />
-        <VerticalBarSeries
-          data={[
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <VerticalBarSeries
-          data={[
-            {x: 1, y: 12},
-            {x: 2, y: 2},
-            {x: 3, y: 11}
-          ]}/>
-      </XYPlot>
+      <BarSeries
+        {...this.props}
+        linePosAttr="x"
+        valuePosAttr="y"
+        lineSizeAttr="width"
+        valueSizeAttr="height"
+      />
     );
   }
 }

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -183,6 +183,19 @@ export default class XYPlot extends React.Component {
       attrProps[key] = props[key];
     });
 
+    const zeroBaseProps = {};
+    ATTRIBUTES.forEach(attr => {
+      getSeriesChildren(props.children).forEach((child, index) => {
+        if (!child) {
+          return;
+        }
+        const {zeroBaseValue} = child.type.getParentConfig(attr, child.props);
+        if (zeroBaseValue) {
+          zeroBaseProps[`${attr}BaseValue`] = 0;
+        }
+      });
+    });
+
     const adjustBy = new Set();
     const adjustWhat = new Set();
     getSeriesChildren(props.children).forEach((child, index) => {
@@ -190,15 +203,25 @@ export default class XYPlot extends React.Component {
         return;
       }
       ATTRIBUTES.forEach(attr => {
-        if (child.type.isDomainAdjustmentNeeded(attr, child.props)) {
+        const {
+          isDomainAdjustmentNeeded,
+          zeroBaseValue} = child.type.getParentConfig(
+            attr,
+            child.props
+          );
+        if (isDomainAdjustmentNeeded) {
           adjustBy.add(attr);
           adjustWhat.add(index);
+        }
+        if (zeroBaseValue) {
+          zeroBaseProps[`${attr}BaseValue`] = 0;
         }
       });
     });
 
     return {
       ...defaults,
+      ...zeroBaseProps,
       ...attrProps,
       _allData: data,
       _adjustBy: Array.from(adjustBy),

--- a/src/lib/utils/data-utils.js
+++ b/src/lib/utils/data-utils.js
@@ -51,15 +51,16 @@ export function isObjectPropertyInUse(arr, propertyName) {
 /**
  * Add zero to the domain.
  * @param {Array} arr Add zero to the domain.
+ * @param {Number} value Add zero to domain.
  * @returns {Array} Adjusted domain.
  */
-export function addZeroToArray(arr) {
+export function addValueToArray(arr, value) {
   const result = [].concat(arr);
-  if (result[0] > 0) {
-    result[0] = 0;
+  if (result[0] > value) {
+    result[0] = value;
   }
-  if (result[result.length - 1] < 0) {
-    result[result.length - 1] = 0;
+  if (result[result.length - 1] < value) {
+    result[result.length - 1] = value;
   }
   return result;
 }


### PR DESCRIPTION
This update does following things:
- Changes the way how the series' flags are passed to the parent (`isDomainAdjustmentNeeded` is moved to `getParentConfig` function). 
- Automatically adds zero to the domain if the series requires that (through zeroBaseValue parent config; see #13 for more detail).
- Replaces existing `BarSeries` with `VerticalBarSeries` and `HorizontalBarSeries` in order to simplify the code.

@uber-common/data-visualization please take a look.
