### PR TITLE
Avoid using static getters for displayName.

### DIFF
--- a/src/lib/make-vis-flexible.js
+++ b/src/lib/make-vis-flexible.js
@@ -32,11 +32,7 @@ const CONTAINER_REF = 'container';
  */
 export default function makeVisFlexible(Component) {
 
-  return class extends React.Component {
-
-    static get displayName() {
-      return `Flexible${Component.displayName}`;
-    }
+  const ResultClass = class extends React.Component {
 
     static get propTypes() {
       const {width, ...otherPropTypes} = Component.propTypes;
@@ -100,4 +96,7 @@ export default function makeVisFlexible(Component) {
 
   };
 
+  ResultClass.displayName = `Flexible${Component.displayName}`;
+
+  return ResultClass;
 }

--- a/src/lib/plot/axis.js
+++ b/src/lib/plot/axis.js
@@ -38,11 +38,7 @@ import {DEFAULT_TICK_SIZE} from '../theme';
  *   to calculate the number of ticks passed.
  * @returns {React.Component} Axis component.
  */
-export default class Axis extends PureRenderComponent {
-
-  static get displayName() {
-    return 'Axis';
-  }
+class Axis extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -167,3 +163,7 @@ export default class Axis extends PureRenderComponent {
     );
   }
 }
+
+Axis.displayName = 'Axis';
+
+export default Axis;

--- a/src/lib/plot/crosshair.js
+++ b/src/lib/plot/crosshair.js
@@ -60,10 +60,7 @@ function getFirstNonEmptyValue(values) {
   return (values || []).find(v => Boolean(v));
 }
 
-export default class Crosshair extends PureRenderComponent {
-  static get displayName() {
-    return 'Crosshair';
-  }
+class Crosshair extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -172,3 +169,7 @@ export default class Crosshair extends PureRenderComponent {
     );
   }
 }
+
+Crosshair.displayName = 'Crosshair';
+
+export default Crosshair;

--- a/src/lib/plot/grid-lines.js
+++ b/src/lib/plot/grid-lines.js
@@ -27,11 +27,7 @@ import {getAttributeScale} from '../utils/scales-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
 
-export default class GridLines extends PureRenderComponent {
-
-  static get displayName() {
-    return 'GridLines';
-  }
+class GridLines extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -107,3 +103,7 @@ export default class GridLines extends PureRenderComponent {
     );
   }
 }
+
+GridLines.displayName = 'GridLines';
+
+export default GridLines;

--- a/src/lib/plot/hint.js
+++ b/src/lib/plot/hint.js
@@ -40,10 +40,7 @@ function defaultFormat(value) {
   });
 }
 
-export default class Hint extends PureRenderComponent {
-  static get displayName() {
-    return 'Hint';
-  }
+class Hint extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -246,3 +243,7 @@ export default class Hint extends PureRenderComponent {
     );
   }
 }
+
+Hint.displayName = 'Hint';
+
+export default Hint;

--- a/src/lib/plot/horizontal-grid-lines.js
+++ b/src/lib/plot/horizontal-grid-lines.js
@@ -25,7 +25,7 @@ import GridLines from './grid-lines';
 import {getScalePropTypesByAttribute} from '../utils/scales-utils';
 import {getTicksTotalFromSize} from '../utils/axis-utils';
 
-export default class HorizontalGridLines extends PureRenderComponent {
+class HorizontalGridLines extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -54,3 +54,7 @@ export default class HorizontalGridLines extends PureRenderComponent {
     );
   }
 }
+
+HorizontalGridLines.displayName = 'HorizontalGridLines';
+
+export default HorizontalGridLines;

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -26,11 +26,7 @@ import {getDOMNode} from '../../utils/react-utils';
 
 import {DEFAULT_OPACITY} from '../../theme';
 
-export default class AreaSeries extends AbstractSeries {
-
-  static get displayName() {
-    return 'AreaSeries';
-  }
+class AreaSeries extends AbstractSeries {
 
   constructor(props) {
     super(props);
@@ -111,3 +107,7 @@ export default class AreaSeries extends AbstractSeries {
   }
 
 }
+
+AreaSeries.displayName = 'AreaSeries';
+
+export default AreaSeries;

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -24,7 +24,7 @@ import d3 from 'd3';
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
 
-export default class BarSeries extends AbstractSeries {
+class BarSeries extends AbstractSeries {
 
   static get propTypes() {
     return {
@@ -143,3 +143,7 @@ export default class BarSeries extends AbstractSeries {
     );
   }
 }
+
+BarSeries.displayName = 'BarSeries';
+
+export default BarSeries;

--- a/src/lib/plot/series/heatmap-series.js
+++ b/src/lib/plot/series/heatmap-series.js
@@ -24,11 +24,7 @@ import d3 from 'd3';
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
 
-export default class HeatmapSeries extends AbstractSeries {
-
-  static get displayName() {
-    return 'HeatmapSeries';
-  }
+class HeatmapSeries extends AbstractSeries {
 
   static getParentConfig(attr) {
     const isDomainAdjustmentNeeded = attr === 'x' || attr === 'y';
@@ -115,5 +111,8 @@ export default class HeatmapSeries extends AbstractSeries {
       </g>
     );
   }
-
 }
+
+HeatmapSeries.displayName = 'HeatmapSeries';
+
+export default HeatmapSeries;

--- a/src/lib/plot/series/horizontal-bar-series.js
+++ b/src/lib/plot/series/horizontal-bar-series.js
@@ -23,7 +23,7 @@ import React from 'react';
 import AbstractSeries from './abstract-series';
 import BarSeries from './bar-series';
 
-export default class HorizontalBarSeries extends AbstractSeries {
+class HorizontalBarSeries extends AbstractSeries {
 
   static getParentConfig(attr) {
     const isDomainAdjustmentNeeded = attr === 'y';
@@ -46,3 +46,7 @@ export default class HorizontalBarSeries extends AbstractSeries {
     );
   }
 }
+
+HorizontalBarSeries.displayName = 'HorizontalBarSeries';
+
+export default HorizontalBarSeries;

--- a/src/lib/plot/series/line-mark-series.js
+++ b/src/lib/plot/series/line-mark-series.js
@@ -24,10 +24,7 @@ import AbstractSeries from './abstract-series';
 import LineSeries from './line-series';
 import MarkSeries from './mark-series';
 
-export default class LineMarkSeries extends AbstractSeries {
-  static get displayName() {
-    return 'LineMarkSeries';
-  }
+class LineMarkSeries extends AbstractSeries {
 
   static get defaultProps() {
     return LineSeries.defaultProps;
@@ -41,5 +38,9 @@ export default class LineMarkSeries extends AbstractSeries {
       </g>
     );
   }
-
 }
+
+LineMarkSeries.displayName = 'LineMarkSeries';
+
+export default LineMarkSeries;
+

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -31,11 +31,7 @@ const STROKE_STYLES = {
   solid: null
 };
 
-export default class LineSeries extends AbstractSeries {
-
-  static get displayName() {
-    return 'LineSeries';
-  }
+class LineSeries extends AbstractSeries {
 
   static get defaultProps() {
     return {
@@ -108,3 +104,7 @@ export default class LineSeries extends AbstractSeries {
     );
   }
 }
+
+LineSeries.displayName = 'LineSeries';
+
+export default LineSeries;

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -26,11 +26,7 @@ import {getDOMNode} from '../../utils/react-utils';
 
 import {DEFAULT_SIZE, DEFAULT_OPACITY} from '../../theme';
 
-export default class MarkSeries extends AbstractSeries {
-
-  static get displayName() {
-    return 'MarkSeries';
-  }
+class MarkSeries extends AbstractSeries {
 
   constructor(props) {
     super(props);
@@ -102,5 +98,9 @@ export default class MarkSeries extends AbstractSeries {
       </g>
     );
   }
-
 }
+
+MarkSeries.displayName = 'MarkSeries';
+
+export default MarkSeries;
+

--- a/src/lib/plot/series/vertical-bar-series.js
+++ b/src/lib/plot/series/vertical-bar-series.js
@@ -23,7 +23,7 @@ import React from 'react';
 import AbstractSeries from './abstract-series';
 import BarSeries from './bar-series';
 
-export default class VerticalBarSeries extends AbstractSeries {
+class VerticalBarSeries extends AbstractSeries {
 
   static getParentConfig(attr) {
     const isDomainAdjustmentNeeded = attr === 'x';
@@ -46,3 +46,7 @@ export default class VerticalBarSeries extends AbstractSeries {
     );
   }
 }
+
+VerticalBarSeries.displayName = 'VerticalBarSeries';
+
+export default VerticalBarSeries;

--- a/src/lib/plot/vertical-grid-lines.js
+++ b/src/lib/plot/vertical-grid-lines.js
@@ -25,7 +25,7 @@ import GridLines from './grid-lines';
 import {getScalePropTypesByAttribute} from '../utils/scales-utils';
 import {getTicksTotalFromSize} from '../utils/axis-utils';
 
-export default class VerticalGridLines extends PureRenderComponent {
+class VerticalGridLines extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -55,3 +55,7 @@ export default class VerticalGridLines extends PureRenderComponent {
     );
   }
 }
+
+VerticalGridLines.displayName = 'VerticalGridLines';
+
+export default VerticalGridLines;

--- a/src/lib/plot/x-axis.js
+++ b/src/lib/plot/x-axis.js
@@ -24,11 +24,7 @@ import PureRenderComponent from '../pure-render-component';
 import Axis from './axis';
 import {getTicksTotalFromSize} from '../utils/axis-utils';
 
-export default class XAxis extends PureRenderComponent {
-
-  static get displayName() {
-    return 'XAxis';
-  }
+class XAxis extends PureRenderComponent {
 
   static get requiresSVG() {
     return true;
@@ -56,3 +52,7 @@ export default class XAxis extends PureRenderComponent {
     );
   }
 }
+
+XAxis.displayName = 'XAxis';
+
+export default XAxis;

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -46,11 +46,7 @@ const ATTRIBUTES = [
 
 import {AnimationPropType} from '../utils/animation-utils';
 
-export default class XYPlot extends React.Component {
-
-  static get displayName() {
-    return 'XYPlot';
-  }
+class XYPlot extends React.Component {
 
   static get propTypes() {
     return {
@@ -294,3 +290,7 @@ export default class XYPlot extends React.Component {
     );
   }
 }
+
+XYPlot.displayName = 'XYPlot';
+
+export default XYPlot;

--- a/src/lib/plot/y-axis.js
+++ b/src/lib/plot/y-axis.js
@@ -23,11 +23,7 @@ import React from 'react';
 import PureRenderComponent from '../pure-render-component';
 import Axis from './axis';
 
-export default class YAxis extends PureRenderComponent {
-
-  static get displayName() {
-    return 'YAXis';
-  }
+class YAxis extends PureRenderComponent {
 
   static get requiresSVG() {
     return true;
@@ -64,3 +60,7 @@ export default class YAxis extends PureRenderComponent {
     );
   }
 }
+
+YAxis.displayName = 'YAxis';
+
+export default YAxis;

--- a/src/lib/radial-chart/radial-chart.js
+++ b/src/lib/radial-chart/radial-chart.js
@@ -243,3 +243,7 @@ export default class RadialChart extends React.Component {
     );
   }
 }
+
+RadialChart.displayName = 'RadialChart';
+
+export default RadialChart;

--- a/src/lib/table/table.js
+++ b/src/lib/table/table.js
@@ -25,11 +25,7 @@ import {getDOMNode} from '../utils/react-utils';
 const HEADER_REF = 'headerRef';
 const DATA_REF = 'dataRef';
 
-export default class Table extends React.Component {
-
-  static get displayName() {
-    return 'Table';
-  }
+class Table extends React.Component {
 
   static get propTypes() {
     return {
@@ -227,3 +223,7 @@ export default class Table extends React.Component {
     );
   }
 }
+
+Table.displayName = 'Table';
+
+export default Table;

--- a/src/lib/treemap/treemap.js
+++ b/src/lib/treemap/treemap.js
@@ -45,11 +45,7 @@ const DEFAULT_SCALES = {
   }
 };
 
-export default class FixedTreemapVis extends React.Component {
-
-  static get displayName() {
-    return 'FixedTreemapVis';
-  }
+class Treemap extends React.Component {
 
   static get propTypes() {
     return {
@@ -228,3 +224,7 @@ export default class FixedTreemapVis extends React.Component {
   }
 
 }
+
+Treemap.displayName = 'Treemap';
+
+export default Treemap;


### PR DESCRIPTION
`static get displayName` produces breaking interference with livereactload. Currently `displayName` property is attached to the class after the class is created.
**Note: This should be changed in future, when static properties will come out of the Babel's stage-0**

@uber-common/data-visualization , please take a look.