### PR TITLE
Changed default animation duration from 100ms to 1000ms

### DIFF
--- a/src/lib/utils/animation-utils.js
+++ b/src/lib/utils/animation-utils.js
@@ -35,7 +35,7 @@ export const AnimationPropType = React.PropTypes.oneOfType([
  * @const
  */
 export const DEFAULT_ANIMATION = {
-  duration: 100
+  duration: 1000
 };
 
 /**


### PR DESCRIPTION
Fix for https://github.com/uber-common/react-vis/issues/23

The default animation duration was very short (100ms). Therefore, the animated treemap didnt seem to animate. It is good to keep default animation to 1000ms.