### PR TITLE
Fixed broken links in RadialChart documentation

### DIFF
--- a/docs/radial-chart.md
+++ b/docs/radial-chart.md
@@ -46,31 +46,31 @@ Data for the chart. Each data object should contain _at least_ `angle` property 
 
 #### angleDomain, angleRange, angleType
 Scale properties for the `angle` scale. The `angle` property _should be_ passed in the data, otherwise the chart won't be shown.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### radiusDomain, radiusRange, radiusType
 Scale properties for the `radius` scale. If the scale is not passed, the maximum possible radius is taken.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### innerRadiusDomain, innerRadiusRange, innerRadiusType
 Scale properties for the `innerRadius` scale. If `innerRadius` property is not passed in the data object, opacity is _not_ visualized.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### opacityDomain, opacityRange, opacityType
 Scale properties for the `opacity` scale. If `opacity` property is not passed in the data object, opacity is _not_ visualized.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### colorDomain, colorRange, colorType
 Scale properties for the `color` scale. If `color` property is not passed in the data object, each new section of the chart gets the next color (e. g. the `'category'` scale is applied).
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### fillDomain, fillRange, fillType
 Scale properties for the `fill` scale. If `fill` property is not passed in the data object, color scale is used insead.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### strokeDomain, strokeRange, strokeType
 Scale properties for the `stroke` scale. If `stroke` property is not passed in the data object, stroke is _not_ visualized.  
-Please refer to [Scales and Data](common-principles.md#scales-and-data) for more information about scales.
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
 
 #### animation (optional)
 Type: `boolean|Object`


### PR DESCRIPTION
The links within the RadialChart docs were 404ing, fixed to point to the correct doc.