### PR TITLE
Enable stacking for area and bar charts

### DIFF
--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -24,6 +24,7 @@ import d3 from 'd3';
 import PureRenderComponent from '../../pure-render-component';
 import {
   getAttributeFunctor,
+  getAttr0Functor,
   getAttributeValue,
   getScaleObjectFromProps,
   getScalePropTypesByAttribute} from '../../utils/scales-utils';
@@ -78,6 +79,16 @@ export default class AbstractSeries extends PureRenderComponent {
   }
 
   /**
+   * Get the attr0 functor.
+   * @param {string} attr Attribute name.
+   * @returns {*} Functor.
+   * @private
+   */
+  _getAttr0Functor(attr) {
+    return getAttr0Functor(this.props, attr);
+  }
+
+  /**
    * Get the attribute value if it is available.
    * @param {string} attr Attribute name.
    * @returns {*} Attribute value if available, fallback value or undefined
@@ -97,22 +108,6 @@ export default class AbstractSeries extends PureRenderComponent {
   _getScaleDistance(attr) {
     const scaleObject = getScaleObjectFromProps(this.props, attr);
     return scaleObject ? scaleObject.distance : 0;
-  }
-
-  _getScaleBaseValue(attr) {
-    const scaleObject = getScaleObjectFromProps(this.props, attr);
-    return scaleObject ? scaleObject.baseValue : 0;
-  }
-
-  /**
-   * Get scale domain for the given attribute.
-   * @param {string} attr Attribute.
-   * @returns {*} Domain or null if not defined.
-   * @protected
-   */
-  _getScaleDomain(attr) {
-    const scaleObject = getScaleObjectFromProps(this.props, attr);
-    return scaleObject ? scaleObject.domain : null;
   }
 
   /**

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -64,20 +64,22 @@ class AreaSeries extends AbstractSeries {
 
   _updateSeries() {
     const lineElement = getDOMNode(this.refs.line);
-    const {data, innerHeight} = this.props;
+    const {data} = this.props;
     if (!data) {
       return;
     }
 
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
+    const y0 = this._getAttr0Functor('y');
     const fill = this._getAttributeValue('fill') ||
       this._getAttributeValue('color');
 
     const stroke = this._getAttributeValue('stroke') ||
       this._getAttributeValue('color');
 
-    const line = d3.svg.area().x(x).y0(innerHeight).y1(y);
+    const line = d3.svg.area().x(x).y0(y0).y1(y);
+
     const opacity = this._getAttributeValue('opacity') || DEFAULT_OPACITY;
     const d = line(data);
 

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -83,33 +83,36 @@ class BarSeries extends AbstractSeries {
   _updateSeries() {
     const container = getDOMNode(this.refs.container);
     const {
-      sameTypeTotal = 1,
-      sameTypeIndex = 0,
-      data} = this.props;
-
-    const {
+      _stackBy,
+      data,
       lineSizeAttr,
       valuePosAttr,
       linePosAttr,
       valueSizeAttr} = this.props;
+
+    let {
+      sameTypeTotal = 1,
+      sameTypeIndex = 0} = this.props;
 
     if (!data || !data.length) {
       return;
     }
 
     const distance = this._getScaleDistance(linePosAttr);
-    const baseValue = this._getScaleBaseValue(valuePosAttr);
     const lineFunctor = this._getAttributeFunctor(linePosAttr);
     const valueFunctor = this._getAttributeFunctor(valuePosAttr);
+    const value0Functor = this._getAttr0Functor(valuePosAttr);
+
+    if (_stackBy === valuePosAttr) {
+      sameTypeTotal = 1;
+      sameTypeIndex = 0;
+    }
 
     const rects = d3.select(container).selectAll('rect')
       .data(data)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);
 
-    const baseCoordinate = valueFunctor({
-      [valuePosAttr]: baseValue
-    });
     const itemSize = (distance / 2) * 0.85;
 
     this._applyTransition(rects)
@@ -123,9 +126,9 @@ class BarSeries extends AbstractSeries {
       )
       .attr(lineSizeAttr, itemSize * 2 / sameTypeTotal)
       .attr(valuePosAttr,
-        d => Math.min(baseCoordinate, valueFunctor(d)))
+        d => Math.min(value0Functor(d), valueFunctor(d)))
       .attr(valueSizeAttr,
-        d => Math.abs(-baseCoordinate + valueFunctor(d)));
+        d => Math.abs(-value0Functor(d) + valueFunctor(d)));
   }
 
   render() {

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -212,7 +212,8 @@ class XYPlot extends React.Component {
       ...attrProps,
       _allData: data,
       _adjustBy: Array.from(adjustBy),
-      _adjustWhat: Array.from(adjustWhat)
+      _adjustWhat: Array.from(adjustWhat),
+      _stackBy: props.stackBy
     };
   }
 


### PR DESCRIPTION
- Add the getAttr0Value to all series: it tries to retrieve the data from [attr]0 property if given property is defined and fall back to baseValue if no property is available.
- Add the proper support of [attr]0 for the area and bar charts (not required for the rest of the series).
- Add the functionality to turn off grouping for bar charts if stacking is enabled.

Tests will follow in the next diff.

@uber-common/data-visualization , please take a look