### PR TITLE
Fix 0 height bars

### DIFF
--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -293,7 +293,8 @@ function _computeRightDomainAdjustment(values) {
  */
 function _computeScaleDistance(values, domain, index, scaleFn) {
   if (values.length > 1) {
-    return Math.abs(scaleFn(values[index]) - scaleFn(values[index - 1]));
+    const i = index > 0 ? index : 1;
+    return Math.abs(scaleFn(values[i]) - scaleFn(values[i - 1]));
   }
   if (values.length === 1) {
     return Math.abs(scaleFn(domain[1]) - scaleFn(domain[0]));

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -286,14 +286,15 @@ function _computeRightDomainAdjustment(values) {
  * Compute distance for the given values.
  * @param {Array} values Array of values.
  * @param {Array} domain Domain.
- * @param {number} index Index of a best distance found.
+ * @param {number} bestDistIndex Index of a best distance found.
  * @param {function} scaleFn Scale function.
  * @returns {number} Domain adjustment.
  * @private
  */
-function _computeScaleDistance(values, domain, index, scaleFn) {
+function _computeScaleDistance(values, domain, bestDistIndex, scaleFn) {
   if (values.length > 1) {
-    const i = index > 0 ? index : 1;
+    // Avoid zero indexes.
+    const i = Math.max(bestDistIndex, 1);
     return Math.abs(scaleFn(values[i]) - scaleFn(values[i - 1]));
   }
   if (values.length === 1) {


### PR DESCRIPTION
0 height bars were caused not by the incorrect calculation of height, but by the wrong calculation of the bar width, when distance NaN instead of a real number. This small change fixes the calculation of distance (e.g. bar width) for the case when the first distance is the shortest.

This pull request fixes #40 .

@uber-common/data-visualization , please review.