### PR TITLE
Adjust version detection to support react@15

### DIFF
--- a/src/lib/utils/react-utils.js
+++ b/src/lib/utils/react-utils.js
@@ -20,11 +20,11 @@
 
 import React from 'react';
 
-const [, versionNumber] = React.version.split('.');
-const versionHigherThanThirteen = Number(versionNumber) > 13;
+const [major, minor] = React.version.split('.');
+const versionHigherThanThirteen = Number(minor) > 13 || Number(major) > 13;
 
 /**
- * Support React 0.13 where refs are React components, not DOM Nodes.
+ * Support React 0.13 and greater where refs are React components, not DOM Nodes.
  * @param {*} ref React's ref.
  * @returns {Element} DOM element.
  */


### PR DESCRIPTION
Hey there!

I've been testing `react@15` (which came out today) with my project, seems like everything works fine apart from the version detection in `react-utils.js` which doesn't cater to the fact that `react` is now using major versions.

This PR fixes the above issue - have smoke tested and seems to be running fine with `react@15` and `react@0.14.x`

Thanks!