### PR TITLE
Fix the category chart when only one value exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.16.1",
     "node-sass": "^3.4.2",
-    "react": ">=0.14.0",
+    "react": ">=0.14.0 <0.15.0",
     "react-addons-test-utils": "^0.14.7",
-    "react-dom": ">=0.14.0",
+    "react-dom": ">=0.14.0 <0.15.0",
     "run-browser-babel": "^4.0.1",
     "tape": "^4.0.0",
     "uglify-js": "^2.6.1"

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -410,8 +410,12 @@ function _adjustContinuousScale(props, scaleObject) {
  */
 function _adjustCategoricalScale(scaleObject) {
   const scaleFn = _getScaleFnFromScaleObject(scaleObject);
-  scaleObject.distance = scaleFn(scaleObject.domain[1]) -
-    scaleFn(scaleObject.domain[0]);
+  const {domain, range} = scaleObject;
+  if (domain.length > 1) {
+    scaleObject.distance = scaleFn(domain[1]) - scaleFn(domain[0]);
+  } else {
+    scaleObject.distance = range[1] - range[0];
+  }
   return scaleObject;
 }
 


### PR DESCRIPTION
In case if only 1 value existed in the chart, the ordinal scale wasn't rendered properly: the calculation of the distance between the chart's columns was broken. This fix adds an additional check for the domain: if the chart has only one value, uses the entire range is used as a distance.

Please check #49 for reference.

@uber-common/data-visualization , please take a look.