### PR TITLE
Ability to use colorRange and opacityRange for the treemap

### DIFF
--- a/src/lib/utils/react-utils.js
+++ b/src/lib/utils/react-utils.js
@@ -24,7 +24,8 @@ const [major, minor] = React.version.split('.');
 const versionHigherThanThirteen = Number(minor) > 13 || Number(major) > 13;
 
 /**
- * Support React 0.13 and greater where refs are React components, not DOM Nodes.
+ * Support React 0.13 and greater where refs are React components, not DOM
+ * nodes.
  * @param {*} ref React's ref.
  * @returns {Element} DOM element.
  */


### PR DESCRIPTION
- Supported `color` and `opacity` scale for the treemap.
- Performed some code cleanup: removed useless `_c` function, `defaultProps` were added, etc.

Also solves the problem of #51 